### PR TITLE
Add simple SLAM simulator

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,33 @@
-# test-repo
-test-repo
+# SLAM Simulator Repository
+
+This repository contains a simple modular simulator for multimodal filter based SLAM.
+
+## Structure
+
+- `slam_sim/` - Package containing the simulator modules:
+  - `sensors.py` - Example sensor classes.
+  - `filter.py` - Implementation of a lightweight Gaussian mixture filter.
+  - `map_manager.py` - Handles map management separately from the filter.
+  - `simulator.py` - Combines everything into a simple SLAM loop.
+- `run_sim.py` - Example script demonstrating usage.
+- `tests/` - Unit tests.
+
+## Usage
+
+Install dependencies (numpy):
+
+```bash
+pip install numpy
+```
+
+Run the simulator example:
+
+```bash
+python run_sim.py
+```
+
+Run tests:
+
+```bash
+python -m unittest discover -v -s tests
+```

--- a/run_sim.py
+++ b/run_sim.py
@@ -1,0 +1,7 @@
+from slam_sim import SLAMSimulator
+
+if __name__ == '__main__':
+    sim = SLAMSimulator()
+    for i in range(5):
+        est = sim.step(control=[0.1, 0.0])
+        print(f"Step {i}: estimate {est}, landmarks: {sim.map.get_landmarks()}")

--- a/slam_sim/__init__.py
+++ b/slam_sim/__init__.py
@@ -1,0 +1,11 @@
+from .sensors import Sensor, Lidar, IMU
+from .filter import MultimodalFilter, GaussianComponent
+from .map_manager import MapManager
+from .simulator import SLAMSimulator
+
+__all__ = [
+    'Sensor', 'Lidar', 'IMU',
+    'MultimodalFilter', 'GaussianComponent',
+    'MapManager',
+    'SLAMSimulator',
+]

--- a/slam_sim/filter.py
+++ b/slam_sim/filter.py
@@ -1,0 +1,31 @@
+import numpy as np
+
+class GaussianComponent:
+    def __init__(self, mean, cov, weight=1.0):
+        self.mean = np.array(mean)
+        self.cov = np.array(cov)
+        self.weight = weight
+
+class MultimodalFilter:
+    """A simple Gaussian mixture filter for SLAM."""
+
+    def __init__(self, components):
+        self.components = components
+
+    def predict(self, control):
+        for c in self.components:
+            c.mean = c.mean + np.array(control)
+
+    def update(self, measurement):
+        # fake update step: adjust weights based on measurement vector length
+        total = 0.0
+        for c in self.components:
+            c.weight *= 1.0 / (1.0 + np.linalg.norm(measurement))
+            total += c.weight
+        for c in self.components:
+            c.weight /= total
+
+    def estimate(self):
+        total_weight = sum(c.weight for c in self.components)
+        mean = sum(c.weight * c.mean for c in self.components) / total_weight
+        return mean

--- a/slam_sim/map_manager.py
+++ b/slam_sim/map_manager.py
@@ -1,0 +1,15 @@
+class MapManager:
+    """Manages the map separately from the filter."""
+
+    def __init__(self):
+        # simple list of landmarks
+        self.landmarks = []
+
+    def add_landmark(self, position):
+        self.landmarks.append(position)
+
+    def get_landmarks(self):
+        return list(self.landmarks)
+
+    def clear(self):
+        self.landmarks.clear()

--- a/slam_sim/sensors.py
+++ b/slam_sim/sensors.py
@@ -1,0 +1,22 @@
+class Sensor:
+    def __init__(self, name):
+        self.name = name
+
+    def read(self):
+        raise NotImplementedError("Sensor.read must be overridden")
+
+class Lidar(Sensor):
+    def __init__(self):
+        super().__init__('Lidar')
+
+    def read(self):
+        # placeholder: return fake distance measurements
+        return {'ranges': [1.0, 1.5, 2.0]}
+
+class IMU(Sensor):
+    def __init__(self):
+        super().__init__('IMU')
+
+    def read(self):
+        # placeholder: return fake acceleration data
+        return {'accel': [0.0, 0.0, -9.81]}

--- a/slam_sim/simulator.py
+++ b/slam_sim/simulator.py
@@ -1,0 +1,28 @@
+from .sensors import Lidar, IMU
+from .filter import GaussianComponent, MultimodalFilter
+from .map_manager import MapManager
+
+class SLAMSimulator:
+    def __init__(self):
+        self.lidar = Lidar()
+        self.imu = IMU()
+        components = [GaussianComponent([0.0, 0.0], [[1.0, 0.0], [0.0, 1.0]])]
+        self.filter = MultimodalFilter(components)
+        self.map = MapManager()
+
+    def step(self, control):
+        # Predict step
+        self.filter.predict(control)
+
+        # Simulated sensor readings
+        lidar_data = self.lidar.read()
+        imu_data = self.imu.read()
+
+        # Update step using arbitrary combination of sensor data
+        measurement = lidar_data['ranges'] + imu_data['accel']
+        self.filter.update(measurement)
+
+        # Map management: add fake landmark based on filter estimate
+        est = self.filter.estimate()
+        self.map.add_landmark(tuple(float(x) for x in est))
+        return est

--- a/tests/test_slam_sim.py
+++ b/tests/test_slam_sim.py
@@ -1,0 +1,12 @@
+import unittest
+from slam_sim import SLAMSimulator
+
+class TestSLAMSimulator(unittest.TestCase):
+    def test_run(self):
+        sim = SLAMSimulator()
+        est = sim.step(control=[0.0, 0.0])
+        self.assertEqual(len(sim.map.get_landmarks()), 1)
+        self.assertEqual(len(est), 2)
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- implement a basic modular SLAM simulator using a multimodal filter
- separate map management logic
- provide runnable example and unit test
- update README with usage instructions

## Testing
- `python -m unittest discover -v -s tests`
- `python run_sim.py`

------
https://chatgpt.com/codex/tasks/task_e_6841a9e690448320b7dfd4aeee9356f9